### PR TITLE
re-arrange program tables to vertical tow-page layout

### DIFF
--- a/abstract-commands.tex
+++ b/abstract-commands.tex
@@ -5,7 +5,7 @@
 % new time slot but without a pagebreak
 \newcommand{\newSmallTimeslot}[1]{\renewcommand{\talkTime}{#1}}
 
-% initialise \conferenceDay 
+% initialise \conferenceDay
 \newcommand{\conferenceDay}{Noday}
 
 
@@ -230,7 +230,8 @@ height=169mm, contents={%
 % define colours
 \definecolor{GHS}{cmyk}{0.16 0 .05 0}
 \definecolor{HSO}{cmyk}{0.02 0 0.12 0.11}
-\definecolor{academic}{cmyk}{0 0.02 0.23 0}
+%\definecolor{academic}{cmyk}{0 0.02 0.23 0}
+\definecolor{academic}{cmyk}{0.35 0 0.33 0.16}
 \definecolor{HSW}{cmyk}{0.35 0 0.33 0.16}
 \definecolor{KHS}{cmyk}{0 .24 0.29 .04}
 \definecolor{Mathematikon C}{cmyk}{.16 0 0.35 0}
@@ -242,7 +243,7 @@ height=169mm, contents={%
   \setAbstract{#1}{#2}{#3}{#4}{GHS}{GHS}
 }
 
-% abstract at HSO 
+% abstract at HSO
 \newcommand{\abstractHSO}[4]%
 {%
   \setAbstract{#1}{#2}{#3}{#4}{HSO}{HSO}
@@ -351,7 +352,7 @@ height=169mm, contents={%
             \includegraphics[width=#2]{#1}
           \end{wrapfigure}
         }
-  
+
         \noindent #4
       }%
     }
@@ -429,16 +430,17 @@ height=169mm, contents={%
 % macro for table rules
 \newcommand{\programCRule}[1]{%
   \arrayrulecolor{tableRuleGray}%
-  \cdashline{#1}[0.2mm/2mm]%
+  \cdashline{#1}[0.2mm/0.4mm]%
 }
 \newcommand{\programHRule}[1]{%
   \arrayrulecolor{tableRuleGray}%
-  \cdashline{2-#1}[0.2mm/2mm]%
+  \cdashline{2-#1}[0.2mm/0.4mm]%
 }
 
 % macro for empty session slots
 \newcommand{\bookableSpace}{
-  & \emph{\textcolor{textGray}{bookable space}}%
+  &
+  \emph{\textcolor{textGray}{bookable space}}%
 }
 
 % diamond symbol for shortened titles
@@ -461,4 +463,9 @@ height=169mm, contents={%
 % macro for no-video icon
 \newcommand{\noVideo}{%
   \includegraphics[height=9pt]{novideo.pdf}%
+}
+
+% skip line to make right/left table columns align
+\newcommand{\skipline}{%
+  \vspace{0.365cm}
 }

--- a/master.tex
+++ b/master.tex
@@ -1,11 +1,12 @@
-\documentclass[
-version=last,toc=bib,toc=graduated,toc=index,toc=listof,fontsize=9pt,openany]{scrbook}
+\documentclass[version=last,toc=bib,toc=graduated,toc=index,toc=listof,fontsize=9pt,openany,twoside]{scrbook}
+%\documentclass[twoside]{article}
 %\pdfminorversion=4
 \usepackage{polyglossia}
 \setdefaultlanguage{english}
 
-\setmainfont{Source Sans Pro}
-\setsansfont{Source Sans Pro}
+\setmainfont{Barlow}
+\setsansfont{Barlow}
+\newfontfamily\numeral{d-din}
 
 \usepackage{ifmtarg}
 \usepackage{ifthen}
@@ -13,7 +14,7 @@ version=last,toc=bib,toc=graduated,toc=index,toc=listof,fontsize=9pt,openany]{sc
 
 \usepackage{geometry}
 \geometry{%a6paper
-paperwidth=125mm, paperheight=168mm, 
+paperwidth=125mm, paperheight=168mm,
 portrait,
 top=22mm,
 inner=22mm,
@@ -33,7 +34,7 @@ footskip=12mm
 \usepackage{relsize}
 
 \clubpenalty=10000
-\widowpenalty=10000 
+\widowpenalty=10000
 \displaywidowpenalty=10000
 
 \usepackage[]{microtype}
@@ -57,7 +58,8 @@ footskip=12mm
 \usepackage{multirow}
 %\usepackage{booktabs}
 
-\usepackage{array}
+%\usepackage{array}
+\usepackage{array,longtable,color}
 
 % dashed lines in tables
 \usepackage{arydshln}
@@ -95,8 +97,25 @@ footskip=12mm
 \input{abstract-commands}
 %\input{sponsor-pagestyles}
 
+% https://tex.stackexchange.com/a/11709/111822
+\newcommand*\cleartoleftpage{%
+  \clearpage
+  \ifodd\value{page}\hbox{}\newpage\fi
+}
+% https://tex.stackexchange.com/a/93810/111822
+\def\widesplit#1{%
+\cleartoleftpage
+\def\row##1##2{##1}%
+#1%
+\clearpage
+\def\row##1##2{##2}%
+#1%
+\clearpage
+}
+
+
 \begin{document}
- 
+
 %\pagestyle{cropmarksstyle}
 \begin{titlepage}
 %  \thispagestyle{titlestyle}
@@ -109,11 +128,12 @@ footskip=12mm
 \input{welcome}
 %\input{scholarships}
 %\input{getting-around}
+
 \input{table-saturday}
 \input{table-sunday}
 \input{table-monday}
-\input{saturday}
-\input{sunday}
+%%%\input{saturday}
+%%%\input{sunday}
 %\input{lightning-talks}
 %\input{osmf}
 %\input{thanks}

--- a/table-monday.tex
+++ b/table-monday.tex
@@ -5,136 +5,190 @@
 \label{monday}
 \pagestyle{monday-table}
 \setPageBackground
-\noindent\begin{landscape}
+\noindent%\begin{landscape}
   \begin{center}
-    \noindent\begin{tabular}{Z{0.75cm}Z{2.38cm};{0.2mm/2mm}Z{2.38cm};{0.2mm/2mm}Z{2.38cm};{0.2mm/2mm}Z{2.38cm};{0.2mm/2mm}}
+
+    %% monday - morning %%
+
+    \makebox[8cm] {
+    \noindent\hspace*{1.3cm}\begin{tabular}[t]{Z{0.75cm}Z{3.6cm};{0.2mm/0.4mm}Z{3.6cm};{0.2mm/0.4mm}Z{1.0cm}}
       \cellcolor{commongray}
-      & \multicolumn{1}{c}{\cellcolor{GHS} GHS}
-      & \multicolumn{1}{c}{\cellcolor{HSO} HSO}
-      & \multicolumn{1}{c}{\cellcolor{KHS} KHS*}
-      & \multicolumn{1}{c}{\cellcolor{Mathematikon C} Mathematikon C*}
+      & \multicolumn{1}{c}{\cellcolor{GHS} Großer Hörsaal}
+      & \multicolumn{1}{c}{\cellcolor{HSO} Hörsaal Ost}
+      & \cellcolor{commongray}
       \tabularnewline
-      \cellcolor{commongray}
-      09:30
+      \cellcolor{commongray} 09:30
       \talk{Qwant Maps: Geocode the World with OSM Data}{Guillaume et\,al.}
       \talk{OSM2World: 3D OSM in your browser}{Tobias Knerr}
-      \longTalk{2}{The Next Generation of Mappers: Learning from YouthMappers \emph{(60 min)}}{Jessica Bergmann}
-      \longTalk{2}{\emph{Workshop (60 min)}\linebreak OpenStreetMap and Wikidata: Awesome Together}{Eugene Alvin Villar}
       \tabularnewline
       \programCRule{2-3}
-      \cellcolor{commongray}
-      10:00
+      \cellcolor{commongray} 10:00
       \talk{Routing for humans}{Sebastian Ritterbusch}
       \talk{Collaborative cartography of cycling infrastructure for route and thematic maps in Medellin, Colombia}{Natalia da Silveira Arruda, Monica Alvarez Valle}
-      &
-      &
       \tabularnewline
-      \programHRule{5}
-      \cellcolor{commongray}
-      10:30
+      \programCRule{2-3}
+      \cellcolor{commongray} 10:30
       \talk{Mapping Mobility in Stockport}{Sam Milson}
       \talk{Lightning Talks IV}{}
-      \talk{OpenStreetMap in Croatia}{Hrvoje Bogner}
-      \bookableSpace
       \tabularnewline
-      \rowcolor{commongray}
-      11:00
-      & \multicolumn{4}{c}{%
+      \rowcolor{commongray} 11:00
+      & \multicolumn{2}{c}{%
       \parbox[c]{24pt}{%
         \includegraphics[height=10pt]{cafe}%
       }
-      break}
-    \end{tabular}
-
-    \noindent\begin{tabular}{Z{0.75cm}Z{2.38cm};{0.2mm/2mm}Z{2.38cm};{0.2mm/2mm}Z{2.38cm};{0.2mm/2mm}Z{2.38cm};{0.2mm/2mm}}
-      \cellcolor{commongray}
-      & \multicolumn{1}{c}{\cellcolor{GHS} GHS}
-      & \multicolumn{1}{c}{\cellcolor{HSO} HSO}
-      & \multicolumn{1}{c}{\cellcolor{KHS} KHS*}
-      & \multicolumn{1}{c}{\cellcolor{Mathematikon C} Mathematikon C*}
+      Break} &
       \tabularnewline
-      \cellcolor{commongray}
-      11:30
+      \cellcolor{commongray} 11:30
       \longTalk{2}{Caretography - Mapping Difficult Issues with OpenStreetMap during Difficult Times \emph{(60 min)}}{David Garcia, Martin Dittus}
       \talk{Integrating and validating open data in OSM using street pictures}{Andrien Pavie}
-      \longTalk{2}{New processes to agree on tagging suggestions and their interaction with the editing software available on osm.org \emph{(60 min)}}{Roland Olbricht}
-      \longTalk{2}{\emph{Workshop (60 min)}\linebreak Custom Presets Creation using JOSM}{Harry Mahardhika Machmud}
       \tabularnewline
       \programCRule{3-3}
-      \cellcolor{commongray}
-      12:00
+      \cellcolor{commongray} 12:00
       &
       \talk{Introduce OpenPlaceReviews and connect to OSM}{Victor Shcherb}
-      &
-      &
       \tabularnewline
-      \programHRule{5}
-      \cellcolor{commongray}
-      12:30
+      \programCRule{2-3}
+      \cellcolor{commongray} 12:30
       \talk{Access to Prosperity: Quantifying Infrastructure Impact With OSM}{Davey Lovin}
       \talk{Lightning Talks VII}{}
+      \tabularnewline
+      \rowcolor{commongray} 13:00
+      & \multicolumn{2}{c}{%
+      \parbox[c]{24pt}{%
+        \includegraphics[height=10pt]{restaurant}%
+      }
+      Lunch} &
+      \tabularnewline
+    \end{tabular}}
+    \newpage
+    \makebox[8cm] {
+    \noindent\hspace*{-1.4cm}\begin{tabular}[t]{Z{1.0cm};{0.2mm/0.4mm}Z{3.6cm};{0.2mm/0.4mm}Z{3.6cm}Z{0.75cm}}
+      \multicolumn{1}{c}{\cellcolor{commongray}}
+      & \multicolumn{1}{c}{\cellcolor{KHS} Kleiner Hörsaal*}
+      & \multicolumn{1}{c}{\cellcolor{Mathematikon C} Mathematikon C*}
+      & \cellcolor{commongray}
+      \tabularnewline
+      \longTalk{2}{The Next Generation of Mappers: Learning from YouthMappers \emph{(60 min)}}{Jessica Bergmann}
+      \longTalk{2}{\emph{Workshop (60 min)}\linebreak OpenStreetMap and Wikidata: Awesome Together}{Eugene Alvin Villar}
+      & \cellcolor{commongray} 09:30 \skipline \skipline
+      \tabularnewline
+      &
+      &
+      & \cellcolor{commongray} 10:00 \skipline \skipline \skipline \skipline
+      \tabularnewline
+      \programCRule{2-3}
+      \talk{OpenStreetMap in Croatia}{Hrvoje Bogner\skipline}
+      \bookableSpace
+      & \cellcolor{commongray} 10:30
+      \tabularnewline
+      \rowcolor{commongray} \multicolumn{1}{c}{}
+      & \multicolumn{2}{c}{%
+      Break
+      \hspace*{14pt}\parbox[c]{14pt}{%
+        \includegraphics[height=10pt]{cafe}%
+      }}
+      & \cellcolor{commongray} 11:00
+      \tabularnewline
+      \longTalk{2}{New processes to agree on tagging suggestions and their interaction with the editing software available on osm.org \emph{(60 min)}}{Roland Olbricht}
+      \longTalk{2}{\emph{Workshop (60 min)}\linebreak Custom Presets Creation using JOSM}{Harry Mahardhika Machmud}
+      & \cellcolor{commongray} 11:30 \skipline \skipline \skipline
+      \tabularnewline
+      &
+      &
+      & \cellcolor{commongray} 12:00 \skipline \skipline
+      \tabularnewline
+      \programCRule{2-3}
       \bookableSpace
       \bookableSpace
+      & \cellcolor{commongray} 12:30 \skipline \skipline \skipline
       \tabularnewline
       \rowcolor{commongray}
+      \multicolumn{1}{c}{} & \multicolumn{2}{c}{%
+      Lunch
+      \hspace*{14pt}\parbox[c]{14pt}{%
+        \includegraphics[height=10pt]{restaurant}%
+      }} &
       13:00
-      & \multicolumn{4}{c}{%
-        \parbox[c]{24pt}{%
-          \includegraphics[height=10pt]{restaurant}%
-        }
-      lunch}
-    \end{tabular}
-
-    \noindent\begin{tabular}{Z{0.75cm}Z{2.38cm};{0.2mm/2mm}Z{2.38cm};{0.2mm/2mm}Z{2.38cm};{0.2mm/2mm}Z{2.38cm};{0.2mm/2mm}}
-      \cellcolor{commongray}
-      & \multicolumn{1}{c}{\cellcolor{GHS} GHS}
-      & \multicolumn{1}{c}{\cellcolor{HSO} HSO}
-      & \multicolumn{1}{c}{\cellcolor{KHS} KHS*}
-      & \multicolumn{1}{c}{\cellcolor{Mathematikon C} Mathematikon C*}
       \tabularnewline
+    \end{tabular}}
+    \newpage
+
+    %% monday - afternoon %%
+
+    \makebox[8cm] {
+    \noindent\hspace*{1.3cm}\begin{tabular}[t]{Z{0.75cm}Z{3.6cm};{0.2mm/0.4mm}Z{3.6cm};{0.2mm/0.4mm}Z{1.0cm}}
       \cellcolor{commongray}
-      14:00
+      & \multicolumn{1}{c}{\cellcolor{GHS} Großer Hörsaal}
+      & \multicolumn{1}{c}{\cellcolor{HSO} Hörsaal Ost}
+      & \cellcolor{commongray}
+      \tabularnewline
+      \cellcolor{commongray} 14:00
       \talk{Pedestrian routing in complex areas: the case of Paris railway stations}{Antoine Riche}
       \talk{Norway: Successful deployment of OSM in Public Transport}{Johan Wiklund}
-      \talk{Participatory Mapping for Open Counties}{Zacharia Muindi}
-      \longTalk{2}{\emph{Workshop (60 min)}\linebreak ImproveOSM~-- MissingRoads workshop}{Beata Tautan-Jancso, Dumitru Laura}
       \tabularnewline
-      \programCRule{2-4}
-      \cellcolor{commongray}
-      14:30
+      \programCRule{2-3}
+      \cellcolor{commongray} 14:30
       \talk{Automatically annotate a pedestrian route with OSM landmarks}{Frédéric Rodrigo}
       \talk{Public Transport Navigation using OSM by OsmAnd}{Victor Shcherb, Eugene Kizevich}
-      \talk{Iranian OSM Community, last two years and the way up front\,**}{E. Hasanzadeh}
-      &
       \tabularnewline
-      \programHRule{5}
-      \cellcolor{commongray}
-      15:00
-      \talk{From car routing to train routing**}{Denis Cheynet}
+      \programCRule{2-3}
+      \cellcolor{commongray} 15:00
+      \talk{From car routing to train routing**}{Denis Cheynet\skipline\skipline}
       \talk{OSM Vector Tiles in custom coordinate systems}{Jiri Komarek}
-      \talk{State of the Map Bangladesh: Transforming A Resilient Community by Institutionalizing OSM}{Tasauf A Baki Billah}
-      &
       \tabularnewline
-      \rowcolor{commongray}
-      15:30
-      & \multicolumn{4}{c}{%
+      \rowcolor{commongray} 15:30
+      & \multicolumn{2}{c}{%
       \parbox[c]{24pt}{%
         \includegraphics[height=10pt]{cafe}%
       }
-      break}
+      Break} &
       \tabularnewline
-      \cellcolor{commongray}
-      16:00
+      \cellcolor{commongray} 16:00
       \talk{Closing}{}
-      &
-      &
-      &
+      & \multicolumn{1}{c}{}
       \tabularnewline
-      \programHRule{5}
-    \end{tabular}
+      \programCRule{2-2}
+    \end{tabular}}
+    \newpage
+    \makebox[8cm] {
+    \noindent\hspace*{-1.4cm}\begin{tabular}[t]{Z{1.0cm};{0.2mm/0.4mm}Z{3.6cm};{0.2mm/0.4mm}Z{3.6cm}Z{0.75cm}}
+      \multicolumn{1}{c}{\cellcolor{commongray}}
+      & \multicolumn{1}{c}{\cellcolor{KHS} Kleiner Hörsaal*}
+      & \multicolumn{1}{c}{\cellcolor{Mathematikon C} Mathematikon C*}
+      & \cellcolor{commongray}
+      \tabularnewline
+      \talk{Participatory Mapping for Open Counties}{Zacharia Muindi\skipline}
+      \longTalk{2}{\emph{Workshop (60 min)}\linebreak ImproveOSM~-- MissingRoads workshop}{Beata Tautan-Jancso, Dumitru Laura}
+      & \cellcolor{commongray} 14:00
+      \tabularnewline
+      \programCRule{2-2}
+      \talk{Iranian OSM Community, last two years and the way up front\,**}{E. Hasanzadeh}
+      &
+      & \cellcolor{commongray} 14:30
+      \tabularnewline
+      \programCRule{2-3}
+      \talk{State of the Map Bangladesh: Transforming A Resilient Community by Institutionalizing OSM}{Tasauf A Baki Billah}
+      \bookableSpace
+      & \cellcolor{commongray} 15:00
+      \tabularnewline
+      \rowcolor{commongray} \multicolumn{1}{c}{}
+      & \multicolumn{2}{c}{%
+      Break
+      \hspace*{14pt}\parbox[c]{14pt}{%
+        \includegraphics[height=10pt]{cafe}%
+      }}
+      & \cellcolor{commongray} 15:30
+      \tabularnewline
+      \multicolumn{3}{c}{}
+      & \cellcolor{commongray} 16:00
+      \tabularnewline
+    \end{tabular}}
+    \newpage
+
+
   \end{center}
   \newpage
 
-  noncommercial advertisements
-\end{landscape}
+  %noncommercial advertisements
+%\end{landscape}
 \renewcommand{\arraystretch}{1.0}

--- a/table-saturday.tex
+++ b/table-saturday.tex
@@ -1,182 +1,243 @@
-\newpage
+\cleartoleftpage
 \small
 \renewcommand{\arraystretch}{1.4}
 %\section*{Saturday Schedule}
 \label{saturday}
 \pagestyle{saturday-table}
 \setPageBackground
-\noindent\begin{landscape}
+\noindent%\begin{landscape}
   \begin{center}
-    \noindent\begin{tabular}{Z{0.75cm}Z{2.38cm};{0.2mm/2mm}Z{2.38cm};{0.2mm/2mm}Z{2.38cm};{0.2mm/2mm}Z{2.38cm};{0.2mm/2mm}}
+
+    %% saturday - morning %%
+
+    \makebox[8cm] {
+    \noindent\hspace*{1.3cm}\begin{tabular}[t]{Z{0.75cm}Z{3.6cm};{0.2mm/0.4mm}Z{3.6cm};{0.2mm/0.4mm}Z{1.0cm}}
+      \rowcolor{commongray} 09:00
+      & \multicolumn{2}{c}{%
+      Registration} &
+      \tabularnewline
       \cellcolor{commongray}
       &
-      \multicolumn{4}{c}{
-        \cellcolor{GHS}
-        GHS
-      }
+      \multicolumn{2}{c}{
+        \cellcolor{GHS} Großer Hörsaal
+      } & \cellcolor{GHS}
       \tabularnewline
-      \cellcolor{commongray}
-      09:30
-      \multiColTalk{4}{Z{9.52cm}}{Welcome}{}
+      \cellcolor{commongray} 09:30
+      \multiColTalk{2}{Z{5.76cm}}{Welcome}{}
       \tabularnewline
-      \programHRule{5}
-      \cellcolor{commongray}
-      10:00
-      \multiColTalk{4}{Z{9.52cm}}{\emph{Keynote} Open up! Why digital mobility needs participation}{Christian Förster, Dietmar Seifert}
+      \programHRule{3}
+      \cellcolor{commongray} 10:00
+      \multiColTalk{2}{Z{5.76cm}}{\emph{Keynote} Open up! Why digital mobility needs participation}{Christian Förster, Dietmar Seifert}
       \tabularnewline
-      \programHRule{5}
-      \cellcolor{commongray}
-      10:30
-      \multiColTalk{4}{Z{9.52cm}}{\emph{Keynote}}{Karen Sandler}
+      \programHRule{3}
+      \cellcolor{commongray} 10:30
+      \multiColTalk{2}{Z{5.76cm}}{\emph{Keynote}}{Karen Sandler}
       \tabularnewline
-      \rowcolor{commongray}
-      11:00
-      & \multicolumn{4}{c}{%
+      \rowcolor{commongray} 11:00
+      & \multicolumn{2}{c}{%
       \parbox[c]{24pt}{%
         \includegraphics[height=10pt]{cafe}%
       }
-      break}
+      Break} &
       \tabularnewline
       \cellcolor{commongray}
-      & \multicolumn{1}{c}{\cellcolor{GHS} GHS}
-      & \multicolumn{1}{c}{\cellcolor{HSO} HSO}
-      & \multicolumn{1}{c}{\cellcolor{HSW} HSW}
-      & \multicolumn{1}{c}{\cellcolor{KHS} KHS*}
+      & \multicolumn{1}{c}{\cellcolor{GHS} Großer Hörsaal}
+      & \multicolumn{1}{c}{\cellcolor{HSO} Hörsaal Ost}
+      & \cellcolor{commongray}
       \tabularnewline
-      \cellcolor{commongray}
-      11:30
+      \cellcolor{commongray} 11:30
       \talk{Get to know OSGeo and how OSGeo is connected to OSM}{Astrid Emde}
       \talk{Data Quality and Feature Extraction at scale with RoboSat.pink}{Oliver Courtin}
-      \longTalk{2}{Introduction to OSM: How it's made and how it's used \emph{(90 min)}}{Thomas Skowron, Frederik Ramm}
-      \longTalk{2}{\emph{Workshop (60 min)}\linebreak Mapping public transport and cycling itineraries using JOSM's PT\_Assistant plugin}{Polyglot}
       \tabularnewline
       \programCRule{2-3}
-      \cellcolor{commongray}
-      12:00
-      \talk{Continuous Ingestion of OSM Data at Facebook\,\diamondSymbol}{Kevin Ventullo, Christopher Klaiber}
+      \cellcolor{commongray} 12:00
+      \talk{“Keepin' it fresh (and good)!”~-- Continuous Ingestion of OSM Data at Facebook}{Kevin Ventullo, Christopher Klaiber}
       \talk{Human Mapping with Machine Data}{Christopher Beddow, Edoardo Neerhut}
-      &
-      &
       \tabularnewline
       \programCRule{2-3}
-      \programCRule{5-5}
-    \end{tabular}
-    \newpage
-
-    \noindent\begin{tabular}{Z{0.75cm}Z{2.38cm};{0.2mm/2mm}Z{2.38cm};{0.2mm/2mm}Z{2.38cm};{0.2mm/2mm}Z{2.38cm};{0.2mm/2mm}}
-      \cellcolor{commongray}
-      & \multicolumn{1}{c}{\cellcolor{GHS} GHS}
-      & \multicolumn{1}{c}{\cellcolor{HSO} HSO}
-      & \multicolumn{1}{c}{\cellcolor{HSW} HSW}
-      & \multicolumn{1}{c}{\cellcolor{KHS} KHS*}
-      \tabularnewline
-      \cellcolor{commongray}
-      12:30
+      \cellcolor{commongray} 12:30
       \talk{Driving South East Asia Forward with OpenStreetMap}{Jinal Foflia}
       \talk{Assisted Intelligence~-- How we map with the support of new technologies}{Felix Delattre, Surabhi Singh}
-      &
-      \bookableSpace
       \tabularnewline
-      \rowcolor{commongray}
-      13:00
-      & \multicolumn{4}{c}{%
+      \rowcolor{commongray} 13:00
+      & \multicolumn{2}{c}{%
       \parbox[c]{24pt}{%
         \includegraphics[height=10pt]{restaurant}%
       }
-      lunch}
+      Lunch} &
+      \tabularnewline
+    \end{tabular}}
+    \newpage
+    \makebox[8cm] {
+    \noindent\hspace*{-1.4cm}\begin{tabular}[t]{Z{1.0cm};{0.2mm/0.4mm}Z{3.6cm};{0.2mm/0.4mm}Z{3.6cm}Z{0.75cm}}
+      \rowcolor{commongray}
+      \multicolumn{1}{c}{}
+      & \multicolumn{2}{c}{%
+      Registration}
+      & 09:00
+      \tabularnewline
+      \multicolumn{1}{c}{} & \multicolumn{2}{c}{} & \cellcolor{commongray} \tabularnewline
+      \multicolumn{1}{c}{} & \multicolumn{2}{c}{} & \cellcolor{commongray} 09:30 \tabularnewline
+      \multicolumn{1}{c}{} & \multicolumn{2}{c}{} & \cellcolor{commongray} 10:00 \vspace{0.73cm} \tabularnewline
+      \multicolumn{1}{c}{} & \multicolumn{2}{c}{} & \cellcolor{commongray} 10:30 \vspace{0.36cm} \tabularnewline
+      \rowcolor{commongray} \multicolumn{1}{c}{}
+      & \multicolumn{2}{c}{%
+      Break
+      \hspace*{14pt}\parbox[c]{14pt}{%
+        \includegraphics[height=10pt]{cafe}%
+      }}
+      & \cellcolor{commongray} 11:00
+      \tabularnewline
+      \multicolumn{1}{c}{\cellcolor{commongray}} & \multicolumn{1}{c}{\cellcolor{HSW} Hörsaal West}
+      & \multicolumn{1}{c}{\cellcolor{KHS} Kleiner Hörsaal*}
+      & \cellcolor{commongray}
+      \tabularnewline
+      \longTalk{2}{Introduction to OSM: How it's made and how it's used \emph{(90 min)}}{Thomas Skowron, Frederik Ramm}
+      \longTalk{2}{\emph{Workshop (60 min)}\linebreak Mapping public transport and cycling itineraries using JOSM's PT\_Assistant plugin}{Polyglot}
+      & \cellcolor{commongray} 11:30 \vspace{1.09cm}
+      \tabularnewline
+      & & & \cellcolor{commongray} 12:00 \vspace{1.81cm}
+      \tabularnewline
+      \programCRule{3-3}
+      &
+      \bookableSpace
+      & \cellcolor{commongray} 12:30 \vspace{1.09cm}
       \tabularnewline
       \rowcolor{commongray}
-      14:00
-      & \multicolumn{4}{c}{%
-      \parbox[c]{24pt}{%
-        \includegraphics[height=10pt]{photo}%
-      }
-      photo (courtyard of Mathematikon building)}
+      \multicolumn{1}{c}{} & \multicolumn{2}{c}{%
+      Lunch
+      \hspace*{14pt}\parbox[c]{14pt}{%
+        \includegraphics[height=10pt]{restaurant}%
+      }} &
+      13:00
       \tabularnewline
-      \cellcolor{commongray}
-      14:30
-      \talk{ODbL license compatibility}{Kathleen Lu}
-      \talk{Lightning Talks I}{}
-      \longTalk{2}{Share Edits and Insights with the Overpass Tools \emph{(60 min)}}{Roland Olbricht}
-      \longTalk{2}{\emph{Workshop (60 min)}\linebreak How to contribute to weeklyOSM via the CMS: OSMBC}{Manfred Reiter}
-      \tabularnewline
-      \programCRule{2-3}
-      \cellcolor{commongray}
-      15:00
-      \talk{Communication and Knowledge Transfer in OSM}{Hanna Krüger}
-      \talk{OsmInEdit~-- a simple indoor editor}{Adrien Pavie et\,al.}
-      &
-      &
-      \tabularnewline
-      \programHRule{5}
-    \end{tabular}
+    \end{tabular}}
     \newpage
 
-    \noindent\begin{tabular}{Z{0.75cm}Z{2.38cm};{0.2mm/2mm}Z{2.38cm};{0.2mm/2mm}Z{2.38cm};{0.2mm/2mm}Z{2.38cm};{0.2mm/2mm}}
-      \cellcolor{commongray}
-      & \multicolumn{1}{c}{\cellcolor{GHS} GHS}
-      & \multicolumn{1}{c}{\cellcolor{HSO} HSO}
-      & \multicolumn{1}{c}{\cellcolor{HSW} HSW}
-      & \multicolumn{1}{c}{\cellcolor{KHS} KHS*}
-      \tabularnewline
-      \cellcolor{commongray}
-      15:30
-      \talk{Past and Future of the OSMF Membership Working Group}{Michael Spreng}
-      \talk{Observe - offline, cross-platform field mapping tool for OpenStreetMap}{Sajjad Anwar}
-      \bookableSpace
-      \bookableSpace
-      \tabularnewline
-      \rowcolor{commongray}
-      16:00
-      & \multicolumn{4}{c}{%
-        \parbox[c]{24pt}{%
-          \includegraphics[height=10pt]{cafe}%
-        }
-      break}
-      \tabularnewline
-      \cellcolor{commongray}
-      16:30
-      \talk{From Digital to Physical Design\,\diamondSymbol}{Yantisa Akhadi}
-      \talk{Lightning Talks II}{}
-      \longTalk{2}{Board and working groups meeting \emph{(90 min, public)}}{}
-      \longTalk{2}{\emph{Workshop (60 min)}\linebreak uMap for newbies}{Manfred Reiter}
-      \tabularnewline
-      \programCRule{2-3}
-      \cellcolor{commongray}
-      17:00
-      \talk{CyclOSM, a bicycle oriented render for every cyclist}{Lucas Verney, Florimond Berthoux}
-      \talk{VR Map: Using OSM Data In a WebVR Environment}{Robert Kaiser}
-      &
-      &
-      \tabularnewline
-      \programCRule{2-3}
-      \programCRule{5-5}
-      \cellcolor{commongray}
-      17:30
-      \talk{How to use OSM data with the Desktop GIS QGIS}{Astrid Emde}
-      \talk{Hikar~-- OSM Augmented Reality for Walkers across Europe}{Nick Whitelegg}
-      &
-      \bookableSpace
-      \tabularnewline
-      \programHRule{5}
-%      \rowcolor{commongray}
-%      19:00
-%      & \multicolumn{4}{c}{%
-%        \parbox[c]{14pt}{%
-%          \includegraphics[height=10pt]{biergarten}%
-%        }
-%        \parbox[c]{14pt}{%
-%          \includegraphics[height=10pt]{bar}%
-%        }
-%        \parbox[c]{24pt}{%
-%          \includegraphics[height=10pt]{restaurant}%
-%        }
-%      social event at Hebelhalle, Hebelstraße 9, 69115 Heidelberg}
-%      \tabularnewline
-    \end{tabular}
-  \end{center}
+  %% saturday - afternoon %%
+
+  \makebox[8cm] {
+  \noindent\hspace*{1.3cm}\begin{tabular}[t]{Z{0.75cm}Z{3.6cm};{0.2mm/0.4mm}Z{3.6cm};{0.2mm/0.4mm}Z{1.0cm}}
+    \cellcolor{commongray}
+    & \multicolumn{1}{c}{\cellcolor{GHS} Großer Hörsaal}
+    & \multicolumn{1}{c}{\cellcolor{HSO} Hörsaal Ost}
+    & \cellcolor{commongray}
+    \tabularnewline
+    \cellcolor{commongray} 14:00
+    \talk{ODbL license compatibility}{Kathleen Lu}
+    \talk{Lightning Talks I}{}
+    \tabularnewline
+    \programCRule{2-3}
+    \cellcolor{commongray} 14:30
+    \talk{Communication and Knowledge Transfer in OSM}{Hanna Krüger}
+    \talk{OsmInEdit~-- a simple indoor editor}{Adrien Pavie et\,al.}
+    \tabularnewline
+    \programCRule{2-3}
+    \cellcolor{commongray} 15:00
+    \talk{Past and Future of the OSMF Membership Working Group}{Michael Spreng}
+    \talk{Observe~-- offline, cross-platform field mapping tool for OpenStreetMap}{Sajjad Anwar}
+    \tabularnewline
+    \programCRule{2-3}
+    \rowcolor{commongray} 15:30
+    & \multicolumn{2}{c}{%
+    \parbox[c]{24pt}{%
+      \includegraphics[height=10pt]{cafe}%
+    }
+    Break} &
+    \tabularnewline
+    \rowcolor{commongray} 16:00
+    & \multicolumn{2}{c}{%
+    \parbox[c]{24pt}{%
+      \includegraphics[height=10pt]{photo}%
+    }
+    Group Photo (courtyard of Mathematikon building)} &
+    \tabularnewline
+    \cellcolor{commongray} 16:30
+    \talk{OSM Data: From Digital to Physical Design}{Yantisa Akhadi}
+    \talk{Lightning Talks II}{}
+    \tabularnewline
+    \programCRule{2-3}
+    \cellcolor{commongray} 17:00
+    \talk{CyclOSM, a bicycle oriented render for every cyclist}{Lucas Verney, Florimond Berthoux}
+    \talk{VR Map: Using OSM Data In a WebVR Environment}{Robert Kaiser}
+    \tabularnewline
+    \programCRule{2-3}
+    \cellcolor{commongray} 17:30
+    \talk{How to use OSM data with the Desktop GIS QGIS}{Astrid Emde}
+    \talk{Hikar~-- OSM Augmented Reality for Walkers across Europe}{Nick Whitelegg}
+    \tabularnewline
+    \programCRule{2-3}
+    \tabularnewline
+    \rowcolor{commongray} 19:00
+    & \multicolumn{2}{c}{%
+    \parbox[c]{24pt}{%
+      \includegraphics[height=10pt]{bar}%
+    }
+    Social Event at HebelHalle} &
+    \tabularnewline
+  \end{tabular}}
+  \newpage
+  \makebox[8cm] {
+  \noindent\hspace*{-1.4cm}\begin{tabular}[t]{Z{1.0cm};{0.2mm/0.4mm}Z{3.6cm};{0.2mm/0.4mm}Z{3.6cm}Z{0.75cm}}
+    \multicolumn{1}{c}{\cellcolor{commongray}} & \multicolumn{1}{c}{\cellcolor{HSW} Hörsaal West}
+    & \multicolumn{1}{c}{\cellcolor{KHS} Kleiner Hörsaal*}
+    & \cellcolor{commongray}
+    \tabularnewline
+          \longTalk{2}{Share Edits and Insights with the Overpass Tools \emph{(60 min)}}{Roland Olbricht}
+          \longTalk{2}{\emph{Workshop (60 min)}\linebreak How to contribute to weeklyOSM via the CMS: OSMBC}{Manfred Reiter}
+    & \cellcolor{commongray} 14:00 \vspace{0.36cm}
+    \tabularnewline
+    & & & \cellcolor{commongray} 14:30 \vspace{0.73cm}
+    \tabularnewline
+    \programCRule{2-3}
+    \bookableSpace
+    \bookableSpace
+    & \cellcolor{commongray} 15:00 \vspace{1.09cm}
+    \tabularnewline
+    \rowcolor{commongray}
+    \multicolumn{1}{c}{} & \multicolumn{2}{c}{%
+    Break
+    \hspace*{14pt}\parbox[c]{14pt}{%
+      \includegraphics[height=10pt]{cafe}%
+    }} &
+    15:30
+    \tabularnewline
+    \rowcolor{commongray}
+    \multicolumn{1}{c}{} & \multicolumn{2}{c}{%
+    Group Photo (courtyard of Mathematikon building)
+    \hspace*{14pt}\parbox[c]{14pt}{%
+      \includegraphics[height=10pt]{photo}%
+    }} &
+    16:00
+    \tabularnewline
+    \longTalk{3}{Board and working groups meeting \emph{(90 min, public)}}{}
+    \longTalk{2}{\emph{Workshop (60 min)}\linebreak uMap for newbies}{Manfred Reiter}
+    & \cellcolor{commongray} 16:30 \skipline \skipline
+    \tabularnewline
+    & & & \cellcolor{commongray} 17:00 \skipline \skipline \skipline
+    \tabularnewline
+    \programCRule{3-3}
+    & \bookableSpace
+    & \cellcolor{commongray} 17:30 \skipline \skipline \skipline
+    \tabularnewline
+    \programCRule{2-3}
+    \multicolumn{1}{c}{}
+    \tabularnewline
+    \rowcolor{commongray}
+    \multicolumn{1}{c}{} & \multicolumn{2}{c}{%
+    Social Event at HebelHalle
+    \hspace*{14pt}\parbox[c]{14pt}{%
+      \includegraphics[height=10pt]{bar}%
+    }}
+    & 19:00
+    \tabularnewline
+  \end{tabular}}
   \newpage
 
-  special page for social event, landscape preferred
-\end{landscape}
+\end{center}
+\newpage
+
+%special page for social event, landscape preferred
+
+%\end{landscape}
 \renewcommand{\arraystretch}{1.0}

--- a/table-sunday.tex
+++ b/table-sunday.tex
@@ -4,224 +4,281 @@
 \label{sunday}
 \pagestyle{sunday-table}
 \setPageBackground
-\noindent\begin{landscape}
+\noindent%\begin{landscape}
   \begin{center}
-    \noindent\begin{tabular}{Z{0.75cm}Z{2.38cm};{0.2mm/2mm}Z{2.38cm};{0.2mm/2mm}Z{2.38cm};{0.2mm/2mm}Z{2.38cm};{0.2mm/2mm}}
+
+    %% sunday - morning 1 %%
+
+    \makebox[8cm] {
+    \noindent\hspace*{1.3cm}\begin{tabular}[t]{Z{0.75cm}Z{3.6cm};{0.2mm/0.4mm}Z{3.6cm};{0.2mm/0.4mm}Z{1.0cm}}
       \cellcolor{commongray}
-      &
-      \multicolumn{4}{c}{
-        \cellcolor{academic}
-        HSW 
-      }
+      & \multicolumn{1}{c}{\cellcolor{GHS} Großer Hörsaal}
+      & \multicolumn{1}{c}{\cellcolor{HSO} Hörsaal Ost}
+      & \cellcolor{commongray}
       \tabularnewline
-      \cellcolor{commongray}
-      09:00
-      \multiColTalk{4}{Z{9.7cm}}{Bridging the Map? Exploring Interactions between the Academic and Mapping Communities in OSM}{A Yair Grinberger et\,al.}
+      \cellcolor{commongray} 09:00 \skipline \skipline \skipline
+      & \multicolumn{2}{c}{} &
       \tabularnewline
-      \cellcolor{commongray}
-      & \multicolumn{1}{c}{\cellcolor{GHS} GHS}
-      & \multicolumn{1}{c}{\cellcolor{HSO} HSO}
-      & \multicolumn{1}{c}{\cellcolor{academic} HSW}
-      & \multicolumn{1}{c}{\cellcolor{KHS} KHS*}
-      \tabularnewline
-      \cellcolor{commongray}
-      09:30
+      \programCRule{2-3}
+      \cellcolor{commongray} 09:30
       \talk{Flexible Routing with GraphHopper}{Peter Karich}
       \talk{``Mapathon, mapathon, mapathon!''}{Séverin Menard, Nicolas Chavent}
-      \talk{OpenStreetMap as a space**}{Dipto Sarkar, So Hoi Kay}
-      &
       \tabularnewline
-      \programHRule{5}
-      \cellcolor{commongray}
-      10:00
+      \programCRule{2-3}
+      \cellcolor{commongray} 10:00
       \talk{Imagery Solutions in OSM}{Kevin Bullock}
-      \talk{Associations dynamics in French speaking Africa\,\diamondSymbol}{Séverin Menard, Nicolas Chavent}
-      \talk{Analysis of OSM data through OSM-Notes user posting}{Toshikazu Seto et\,al.}
-      \talk{Lightning Talks}{various scholars}
+      \talk{OSMF local chapters in countries of the Global South what can we learn from OSM associations dynamics in French-speaking southern countries of Africa and the Caribbean ?}{Séverin Menard, Nicolas Chavent}
       \tabularnewline
-      \programHRule{5}
-      \cellcolor{commongray}
-      10:30
+      \programCRule{2-3}
+      \cellcolor{commongray} 10:30 \skipline \skipline \skipline \skipline
       \talk{Lightning Talks III}{}
       \talk{Tales from the Tasking Manager}{Ramya Ragupathy et\,al.}
-      \talk{A novel application of models of species abundance\,\diamondSymbol}{Peter Mooney}
-      \talk{Lightning Talks}{various scholars}
       \tabularnewline
-      \programHRule{5}
-    \end{tabular}
-  \end{center}
-  \newpage
-
-  \begin{center}
-    \noindent\begin{tabular}{Z{0.75cm}Z{1.80cm};{0.2mm/2mm}Z{1.80cm};{0.2mm/2mm}Z{2.60cm};{0.2mm/2mm}Z{1.40cm};{0.2mm/2mm}Z{1.60cm};{0.2mm/2mm}}
-      \cellcolor{commongray}
-      & \multicolumn{1}{c}{\cellcolor{GHS} GHS}
-      & \multicolumn{1}{c}{\cellcolor{HSO} HSO}
-      & \multicolumn{1}{c}{\cellcolor{HSW} HSW}
-      & \multicolumn{1}{c}{\cellcolor{KHS} KHS*}
-      & \multicolumn{1}{c}{\cellcolor{Mathematikon C} Mathem. C*}
-      \tabularnewline
-      \rowcolor{commongray}
-      11:00
-      & \multicolumn{5}{c}{%
+      \rowcolor{commongray} 11:00
+      & \multicolumn{2}{c}{%
       \parbox[c]{24pt}{%
         \includegraphics[height=10pt]{cafe}%
       }
-      break}
+      Break} &
       \tabularnewline
-      \cellcolor{commongray}
-      11:30
-      \talk{Overview of map serving architectures}{Paul Norman}
-      \talk{Our Falkirk~-- Mitigating the Impacts of Poverty\,\diamondSymbol}{Alison Moon}
-      \talk{Towards Scalable Remote Sensing for Efficient OSM Labeling\,**\,\diamondSymbol}{Rui Zhang et\,al.}
-      \longTalk{3}{Bilingual Breakout Session \emph{(90 min)}}{}
-      \longTalk{2}{\emph{Workshop (60 min)}\linebreak First steps with OpenStreetMap editors}{Angjelina Dervishaj}
+    \end{tabular}}
+    \newpage
+    \makebox[8cm] {
+    \noindent\hspace*{-1.4cm}\begin{tabular}[t]{Z{1.0cm};{0.2mm/0.4mm}Z{3.6cm};{0.2mm/0.4mm}Z{3.6cm}Z{0.75cm}}
+      \multicolumn{1}{c}{\cellcolor{commongray}}
+      & \multicolumn{1}{c}{\cellcolor{HSW} Hörsaal West}
+      & \multicolumn{1}{c}{\cellcolor{KHS} Kleiner Hörsaal*}
+      & \cellcolor{commongray}
       \tabularnewline
-      \programCRule{2-4}
-      \cellcolor{commongray}
-      12:00
-      \talk{Customizing Search for Special-Interest Maps}{Sarah Hoffmann}
-      \talk{Metrics to monitor Buildings outbounds\,\diamondSymbol}{Pierre Béland}
-      \talk{Estimating latent energy demand of buildings}{Nikola Milojevic-Dupont et\,al.}
-      &
-      &
+      \talk{Bridging the Map? Exploring Interactions between the Academic and Mapping Communities in OSM}{A Yair Grinberger et\,al.}
+      & \multicolumn{1}{c}{}
+      & \cellcolor{commongray} 09:00
       \tabularnewline
-      \programCRule{2-4}
-      \programCRule{6-6}
-      \cellcolor{commongray}
-      12:30
-      \talk{Is your OSM App spying on you?}{Thomas Skowron}
-      \talk{Integrating Quality Assurance Checks into Map Editors\,\diamondSymbol}{David Manzer et\,al.}
-      \talk{Client-side route planning: preprocessing the OpenStreetMap road network for Routable Tiles}{Harm Delva et\,al.}
-      &
-      \bookableSpace
+      \programCRule{2-2}
+      \talk{OpenStreetMap as a space**}{Dipto Sarkar, So Hoi Kay}
+      & \multicolumn{1}{c}{}
+      & \cellcolor{commongray} 09:30 \vspace{1.095cm}
       \tabularnewline
-      \programHRule{6}
-    \end{tabular}
-  \end{center}
-  \newpage
+      \programCRule{2-3}
+      \talk{Analysis of OSM data through OSM-Notes user posting}{Toshikazu Seto et\,al.}
+      \talk{Lightning Talks}{SotM scholars}
+      & \cellcolor{commongray} 10:00 \vspace{2.92cm}
+      \tabularnewline
+      \programCRule{2-3}
+      \talk{A novel application of models of species abundance to better understand OpenStreetMap Community structure and interactions}{Peter Mooney}
+      \talk{Lightning Talks}{SotM scholars}
+      & \cellcolor{commongray} 10:30
+      \tabularnewline
+      \rowcolor{commongray} \multicolumn{1}{c}{}
+      & \multicolumn{2}{c}{%
+      Break
+      \hspace*{14pt}\parbox[c]{14pt}{%
+        \includegraphics[height=10pt]{cafe}%
+      }}
+      & \cellcolor{commongray} 11:00
+      \tabularnewline
+    \end{tabular}}
+    \newpage
 
-  \begin{center}
-    \noindent\begin{tabular}{Z{0.75cm}Z{1.80cm};{0.2mm/2mm}Z{1.80cm};{0.2mm/2mm}Z{2.60cm};{0.2mm/2mm}Z{1.40cm};{0.2mm/2mm}Z{1.60cm};{0.2mm/2mm}}
+    %% sunday - midday %%
+
+    \makebox[8cm] {
+    \noindent\hspace*{1.3cm}\begin{tabular}[t]{Z{0.75cm}Z{3.6cm};{0.2mm/0.4mm}Z{3.6cm};{0.2mm/0.4mm}Z{1.0cm}}
       \cellcolor{commongray}
-      & \multicolumn{1}{c}{\cellcolor{GHS} GHS}
-      & \multicolumn{1}{c}{\cellcolor{HSO} HSO}
-      & \multicolumn{1}{c}{\cellcolor{HSW} HSW}
-      & \multicolumn{1}{c}{\cellcolor{KHS} KHS*}
-      & \multicolumn{1}{c}{\cellcolor{Mathematikon C} Mathem. C*}
+      & \multicolumn{1}{c}{\cellcolor{GHS} Großer Hörsaal}
+      & \multicolumn{1}{c}{\cellcolor{HSO} Hörsaal Ost}
+      & \cellcolor{commongray}
       \tabularnewline
-      \rowcolor{commongray}
-      13:00
-      & \multicolumn{5}{c}{%
+      \cellcolor{commongray} 11:30
+      \talk{Overview of map serving architectures}{Paul Norman}
+      \talk{“Our Falkirk”: Mitigating the Impacts of Poverty using OSM Data Themes}{Alison Moon}
+      \tabularnewline
+      \programCRule{2-3}
+      \cellcolor{commongray} 12:00
+      \talk{Customizing Search for Special-Interest Maps}{Sarah Hoffmann}
+      \talk{OSM Quality Mapping : Metrics to monitor Buildings outbounds}{Pierre Béland}
+      \tabularnewline
+      \programCRule{2-3}
+      \cellcolor{commongray} 12:30
+      \talk{Is your OSM App spying on you?}{Thomas Skowron}
+      \talk{Bringing Validation to Users: Integrating Quality Assurance Checks into Map Editors}{David Manzer et\,al.}
+      \tabularnewline
+      \rowcolor{commongray} 13:00
+      & \multicolumn{2}{c}{%
       \parbox[c]{24pt}{%
         \includegraphics[height=10pt]{restaurant}%
       }
-      lunch}
+      Lunch} &
       \tabularnewline
-      \cellcolor{commongray}
-      14:00
+      \cellcolor{commongray} 14:00
       \talk{What's behind JOSM?}{Vincent Privat}
-      \talk{Spatial Indexes for OSM in PostGIS}{Felix Kunde}
-      \talk{Intrinsic assessment of contribution patterns using Exploratory Spatial Data Analysis\,\diamondSymbol}{Marco Minghini et\,al.}
-      \longTalk{2}{Diversity and Inclusion in OSM \emph{(60 min)}}{Patricia Solis et\,al.}
-      \longTalk{2}{\emph{Workshop (60 min)}\linebreak Using OSMCha to understand bad edits}{Andrey Golovin et\,al.}
+      \talk{Spatial Indexes for OSM in PostGIS}{Felix Kunde\skipline\skipline\skipline}
       \tabularnewline
-      \programCRule{2-4}
-      \cellcolor{commongray}
-      14:30
-      \talk{Mapping solar panels can save megatons of CO2}{Dan Stowell, Jerry Clough}
+      \programCRule{2-3}
+      \cellcolor{commongray} 14:30
+      \talk{Mapping solar panels can save megatons of CO2}{Dan Stowell, Jerry Clough\skipline\skipline\skipline}
       \talk{Lightning Talks IV}{}
-      \talk{Corporate Editors in the Evolving Landscape of OSM: A Close Investigation of the Impact to the Map \& Community}{Jennings Anderson et\,al.}
+      \tabularnewline
+      \programCRule{2-3}
+    \end{tabular}}
+    \newpage
+    \makebox[8cm] {
+    \noindent\hspace*{-1.4cm}\begin{tabular}[t]{Z{1.0cm};{0.2mm/0.4mm}Z{3.6cm};{0.2mm/0.4mm}Z{1.6cm};{0.2mm/0.4mm}Z{1.6cm}Z{0.75cm}}
+      \multicolumn{1}{c}{\cellcolor{commongray}}
+      & \multicolumn{1}{c}{\cellcolor{HSW} Hörsaal~West}
+      & \multicolumn{1}{c}{\cellcolor{KHS} Kleiner H.*}
+      & \multicolumn{1}{c}{\cellcolor{Mathematikon C} Mathem. C}
+      & \cellcolor{commongray}
+      \tabularnewline
+      \talk{Towards Scalable Geospatial Remote Sensing for Efficient OSM Labeling\,**}{Rui Zhang et\,al.}
+      \longTalk{3}{Bilingual Breakout Session \emph{(90 min)}}{}
+      \longTalk{2}{\emph{Workshop (60 min)}\linebreak First steps with OpenStreetMap editors}{Angjelina Dervishaj}
+      & \cellcolor{commongray} 11:30
+      \tabularnewline
+      \programCRule{2-2}
+      \talk{Estimating latent energy demand of buildings}{Nikola Milojevic-Dupont et\,al.}
       &
       &
-      \tabularnewline
-      \programHRule{6}
-    \end{tabular}
-  \end{center}
-  \newpage
-
-  \begin{center}
-    \noindent\begin{tabular}{Z{0.75cm}Z{1.80cm};{0.2mm/2mm}Z{1.80cm};{0.2mm/2mm}Z{2.60cm};{0.2mm/2mm}Z{1.40cm};{0.2mm/2mm}Z{1.60cm};{0.2mm/2mm}}
-      \cellcolor{commongray}
-      & \multicolumn{1}{c}{\cellcolor{GHS} GHS}
-      & \multicolumn{1}{c}{\cellcolor{HSO} HSO}
-      & \multicolumn{1}{c}{\cellcolor{HSW} HSW}
-      & \multicolumn{1}{c}{\cellcolor{KHS} KHS*}
-      & \multicolumn{1}{c}{\cellcolor{Mathematikon C} Mathem. C*}
-      \tabularnewline
-      \cellcolor{commongray}
-      15:00
-      \talk{National Trust~-- Managing a Path inventory in OSM: Towards an Open Paths standard in OSM for the UK}{Huw Davies}
-      \longTalk{2}{OSM data processing with PostgreSQL/\allowbreak PostGIS \emph{(60 min)}}{Jochen Topf}
-      \talk{Exploring the Effects of Pokémon Go Vandalism on OSM}{Levente Juhász et\,al.}
-      \longTalk{2}{Local Chapters Congress \emph{(60 min)}}{Joost Schouppe}
-      \bookableSpace
+      & \cellcolor{commongray} 12:00 \vspace{1.095cm}
       \tabularnewline
       \programCRule{2-2}
       \programCRule{4-4}
-      \programCRule{6-6}
-      \cellcolor{commongray}
-      15:30
-      \talk{OpenDatathon activities in Japan}{Shinji Enoki}
-      &
-      \talk{Analyzing the spatio-temporal patterns and impacts of large-scale data production events in OSM}{A Yair Grinberger et\,al.}
+      \talk{Client-side route planning: preprocessing the OpenStreetMap road network for Routable Tiles}{Harm Delva et\,al.}
       &
       \bookableSpace
+      & \cellcolor{commongray} 12:30
       \tabularnewline
       \rowcolor{commongray}
-      16:00
-      & \multicolumn{5}{c}{%
+      \multicolumn{1}{c}{} & \multicolumn{3}{c}{%
+      Lunch
+      \hspace*{14pt}\parbox[c]{14pt}{%
+        \includegraphics[height=10pt]{restaurant}%
+      }} &
+      13:00
+      \tabularnewline
+      \talk{Intrinsic assessment of OpenStreetMap contribution patterns through Exploratory Spatial Data Analysis}{Marco Minghini et\,al.}
+      \longTalk{2}{Diversity and Inclusion in OSM \emph{(60 min)}}{Patricia Solis et\,al.}
+      \longTalk{2}{\emph{Workshop (60 min)}\linebreak Using OSMCha to understand bad edits}{Andrey Golovin et\,al.}
+      & \cellcolor{commongray} 14:00
+      \tabularnewline
+      \programCRule{2-2}
+      \talk{Corporate Editors in the Evolving Landscape of OSM: A Close Investigation of the Impact to the Map \& Community}{Jennings Anderson et\,al.}
+      &
+      &
+      & \cellcolor{commongray} 14:30
+      \tabularnewline
+      \programCRule{2-4}
+    \end{tabular}}
+    \newpage
+
+    %% sunday - afternoon %%
+
+    \makebox[8cm] {
+    \noindent\hspace*{1.3cm}\begin{tabular}[t]{Z{0.75cm}Z{3.6cm};{0.2mm/0.4mm}Z{3.6cm};{0.2mm/0.4mm}Z{1.0cm}}
+      \cellcolor{commongray}
+      & \multicolumn{1}{c}{\cellcolor{GHS} Großer Hörsaal}
+      & \multicolumn{1}{c}{\cellcolor{HSO} Hörsaal Ost}
+      & \cellcolor{commongray}
+      \tabularnewline
+      \cellcolor{commongray} 15:00
+      \talk{National Trust~-- Managing a Path inventory in OSM: Towards an Open Paths standard in OSM for the UK}{Huw Davies}
+      \longTalk{2}{OSM data processing with PostgreSQL/\allowbreak PostGIS \emph{(60 min)}}{Jochen Topf}
+      \tabularnewline
+      \cellcolor{commongray} 15:30 \skipline \skipline \skipline \skipline
+      \talk{OpenDatathon activities in Japan}{Shinji Enoki}
+      &
+      \tabularnewline
+      \programCRule{2-2}
+      \rowcolor{commongray} 16:00
+      & \multicolumn{2}{c}{%
       \parbox[c]{24pt}{%
         \includegraphics[height=10pt]{cafe}%
       }
-      break}
+      Break} &
       \tabularnewline
-    \end{tabular}
-  \end{center}
-  \newpage
-
-  \begin{center}
-    \noindent\begin{tabular}{Z{0.75cm}Z{2.20cm};{0.2mm/2mm}Z{1.40cm};{0.2mm/2mm}Z{2.60cm};{0.2mm/2mm}Z{1.40cm};{0.2mm/2mm}Z{1.60cm};{0.2mm/2mm}}
-      \cellcolor{commongray}
-      & \multicolumn{1}{c}{\cellcolor{GHS} GHS}
-      & \multicolumn{1}{c}{\cellcolor{HSO} HSO}
-      & \multicolumn{1}{c}{\cellcolor{HSW} HSW}
-      & \multicolumn{1}{c}{\cellcolor{KHS} KHS*}
-      & \multicolumn{1}{c}{\cellcolor{Mathematikon C} Mathem. C*}
-      \tabularnewline
-      \cellcolor{commongray}
-      16:30
-      \talk{Notes: Can we do better. Experiences and Ideas from the Frontline}{Chris Fleming}
+      \cellcolor{commongray} 16:30
+      \talk{Notes: Can we do better. Experiences and Ideas from the Frontline}{Chris Fleming\skipline}
       \talk{Mapper's privacy}{Roland Olbricht}
-      \talk{Development after Displacement: Using OSM data to measure SDG indicators at informal settlements}{Hannah Friedrich et\,al.}
-      \talk{Lightning Talks Scholars III}{various scholars}
-      \longTalk{2}{\emph{Workshop (60 min)}\linebreak JOSM Turn Restriction: Improving Data Quality}{Harry Mahardhika Machmud}
       \tabularnewline
-      \programCRule{2-5}
-      \cellcolor{commongray}
-      17:00
-      \talk{Is the OSM data model creaking?}{Marc Lucas-Smith}
+      \programCRule{2-3}
+      \cellcolor{commongray} 17:00
+      \talk{Is the OSM data model creaking?}{Marc Lucas-Smith\skipline\skipline\skipline}
       \talk{Teams for OpenStreetMap}{Marc Farra}
+      \tabularnewline
+      \programCRule{2-3}
+      \cellcolor{commongray}
+      17:30
+      \talk{Broken Promises and Technical Difficulties}{Ilya Zverev\skipline}
+      \talk{Lightning Talks V}{}
+      \tabularnewline
+      \rowcolor{commongray} 18:00
+      & \multicolumn{2}{c}{%
+      \parbox[c]{24pt}{%
+        \includegraphics[height=10pt]{bar}%
+      }
+      Poster Event at Mathematikon} &
+      \tabularnewline
+    \end{tabular}}
+    \newpage
+    \makebox[8cm] {
+    \noindent\hspace*{-1.4cm}\begin{tabular}[t]{Z{1.0cm};{0.2mm/0.4mm}Z{3.6cm};{0.2mm/0.4mm}Z{1.6cm};{0.2mm/0.4mm}Z{1.6cm}Z{0.75cm}}
+      \multicolumn{1}{c}{\cellcolor{commongray}}
+      & \multicolumn{1}{c}{\cellcolor{HSW} Hörsaal~West}
+      & \multicolumn{1}{c}{\cellcolor{KHS} Kleiner H.*}
+      & \multicolumn{1}{c}{\cellcolor{Mathematikon C} Mathem. C}
+      & \cellcolor{commongray}
+      \tabularnewline
+      \talk{Exploring the Effects of Pokémon Go Vandalism on OSM}{Levente Juhász et\,al.\skipline}
+      \longTalk{2}{Local Chapters Congress \emph{(60 min)}}{Joost Schouppe}
+      \bookableSpace
+      & \cellcolor{commongray} 15:00
+      \tabularnewline
+      \programCRule{2-2}
+      \talk{Analyzing the spatio-temporal patterns and impacts of large-scale data production events in OSM}{A Yair Grinberger et\,al.}
+      &
+      &
+      & \cellcolor{commongray} 15:30
+      \tabularnewline
+      \rowcolor{commongray} \multicolumn{1}{c}{}
+      & \multicolumn{3}{c}{%
+      Break
+      \hspace*{14pt}\parbox[c]{14pt}{%
+        \includegraphics[height=10pt]{cafe}%
+      }}
+      & \cellcolor{commongray} 16:00
+      \tabularnewline
+      \talk{Development after Displacement: Using OSM data to measure SDG indicators at informal settlements}{Hannah Friedrich et\,al.}
+      \talk{Lightning Talks}{SotM scholars}
+      \longTalk{2}{\emph{Workshop (60 min)}\linebreak JOSM Turn Restriction: Improving Data Quality}{Harry Mahardhika Machmud}
+      & \cellcolor{commongray} 16:30
+      \tabularnewline
+      \programCRule{2-3}
       \talk{Analysis of OSM data quality at different stages of a participatory mapping process: Evidence from informal urban settings}{Godwin Yeboah et\,al.}
       \longTalk{2}{Nomad Maps, an andean cartographic itinerancy by bike \emph{(60 min video)}}{Alban Vivert}
       &
+      & \cellcolor{commongray} 17:00
       \tabularnewline
-      \programCRule{2-4}
-      \programCRule{6-6}
-      \cellcolor{commongray}
-      17:30
-      \talk{Broken Promises and Technical Difficulties}{Ilya Zverv}
-      \talk{Lightning Talks V}{}
+      \programCRule{2-2}
+      \programCRule{4-4}
       \talk{Assessing the Completeness of Urban Green Spaces in OSM}{Christina Ludwig et\,al.}
       &
       \bookableSpace
+      & \cellcolor{commongray} 17:30
       \tabularnewline
-      \programHRule{6}
-    \end{tabular}
+      \rowcolor{commongray}
+      \multicolumn{1}{c}{} & \multicolumn{3}{c}{%
+      Poster Event at Mathematikon
+      \hspace*{14pt}\parbox[c]{14pt}{%
+        \includegraphics[height=10pt]{bar}%
+      }}
+      & 18:00
+      \tabularnewline
+    \end{tabular}}
+    \newpage
   \end{center}
-  \newpage
 
-  Informations about the poster event go here.
-\end{landscape}
+
+  %Informations about the poster event go here.
+%\end{landscape}
 \renewcommand{\arraystretch}{1.0}
 \normalsize

--- a/welcome.tex
+++ b/welcome.tex
@@ -1,6 +1,6 @@
 \newpage
 \enlargethispage{1\baselineskip}
-\section*{Welcome to Heidelberg and State of the Map 2019} \label{welcome}
+\section*{Welcome to Heidelberg and State of the Map \numeral{2019}} \label{welcome}
 This booklet provides you essential information
 about the conference, the location and the schedule.  We are proud of the participation of the
 OpenStreetMap community and our rich program but there is even more!  Please do get involved and


### PR DESCRIPTION
Changed program tables to use two-page spanning vertical layout, to allow full titles of talks to fit.

Here's a before/after of the citical day (Sunday, 5 parallel tracks):

<img width="45%" src="https://user-images.githubusercontent.com/1927298/62878243-fd72a000-bd28-11e9-8aa5-60463516d16a.png"> → <img width="45%" src="https://user-images.githubusercontent.com/1927298/62878260-0499ae00-bd29-11e9-910e-14490299bee7.png">

<img width="45%" src="https://user-images.githubusercontent.com/1927298/62878272-0bc0bc00-bd29-11e9-9779-201441050143.png"> → <img width="45%" src="https://user-images.githubusercontent.com/1927298/62878276-0d8a7f80-bd29-11e9-9b54-28dd3c9a2875.png">

<img width="45%" src="https://user-images.githubusercontent.com/1927298/62878284-11b69d00-bd29-11e9-8982-a8aa17de7b5e.png"> → <img width="45%" src="https://user-images.githubusercontent.com/1927298/62878293-17ac7e00-bd29-11e9-8c92-07d0828cdcf6.png">

[full table rendering](https://github.com/osmfoundation/sotm2019-booklet/files/3493352/master.pdf)

This PR also includes a few additional changes:
* changed fonts to barlow/d-din as on our logo and website
* more prominent dashed lines around talk slots
* moved photo to saturday afternoon break
* slight rewording of breaks / events
* fixed a few typos (speaker name)