### PR TITLE
remove superfluous page break

### DIFF
--- a/thanks.tex
+++ b/thanks.tex
@@ -1,9 +1,8 @@
-\newpage
 \section*{Thanks}
 \label{thanks}
 \pagestyle{cropmarksstyle}
 %% short version:
-% This conference would not have been possible without the huge support of a lot of volunteers. 
+% This conference would not have been possible without the huge support of a lot of volunteers.
 % We greatfully thank everybody involved.
 %
 %Each year when we write this section we are reminded why OpenStreetMap is so great---it's the dedication


### PR DESCRIPTION
otherwise the two-page ad from the platinum sponsor would start on an odd page, thus not actually spanning two adjacent pages